### PR TITLE
Pkg config in effects

### DIFF
--- a/effects/Makefile
+++ b/effects/Makefile
@@ -3,8 +3,8 @@
 include ../config.mk
 
 CC = gcc
-CFLAGS = $(CONFIG) $(CONFIG.arch) $(CFLAGS.opt) -I.. -I../v4lutils `sdl-config --cflags`
-LIBS = ../v4lutils/libv4lutils.a -lm `sdl-config --libs`
+CFLAGS = $(CONFIG) $(CONFIG.arch) $(CFLAGS.opt) -I.. -I../v4lutils `pkg-config --cflags sdl2`
+LIBS = ../v4lutils/libv4lutils.a -lm `pkg-config --libs sdl2`
 
 LIBEFFECTS = libeffects.a
 EFFECTS = $(DUMB) $(QUARK) $(FIRE) $(BURN) $(BLURZOOM) $(BALTAN) $(STREAK) \


### PR DESCRIPTION
I was trying to compile EffecTV on my ubuntu 20.04, but it failed because it asked to have `sdl-config` on my box
```
gcc -DDEFAULT_VIDEO_DEVICE=\""/dev/video0"\"  -O3 -fomit-frame-pointer -funroll-loops -I.. -I../v4lutils `sdl-config --cflags` -Wall -c -o dumb.o dumb.c
/bin/sh: 1: sdl-config: not found
```

It would work by installing `libsdl1.2-dev` on my box, but it felt wrong so I found that there were wrong references in the `/effects/Makefile`. Here is the fix.