### PR TITLE
Fix linking issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 effectv
 v4lutils/v4ltest
+core

--- a/main.c
+++ b/main.c
@@ -258,11 +258,7 @@ static int startTV(const char *startEffect)
 			} else {
 				if(screen_lock() == 0) {
 					src = (RGB32 *)video_getaddress();
-					if(stretch) {
-						dest = stretching_buffer;
-					} else {
-						dest = (RGB32 *)screen_getaddress();
-					}
+					dest = (RGB32 *)screen_getaddress();
 
 					ret = currentEffect->draw(src, dest);
 

--- a/screen.c
+++ b/screen.c
@@ -14,6 +14,9 @@
 #include "EffecTV.h"
 #include "utils.h"
 
+/* Defined in image.c */
+extern RGB32 *stretching_buffer;
+
 /* Main screen for displaying video image */
 SDL_Surface *screen;
 SDL_Window *window;

--- a/utils.h
+++ b/utils.h
@@ -34,8 +34,6 @@ void fastsrand(unsigned int);
 /*
  * image.c
  */
-
-RGB32 *stretching_buffer;
 int image_init(void);
 void image_end(void);
 void image_stretching_buffer_clear(RGB32 color);


### PR DESCRIPTION
Using gcc11, the compilation fails at link time with multiple definitions of `stretching_buffer`.

Also, `screen_getaddress()` already checks for the `stretch` value, so there is no need to check it in `main.c`.